### PR TITLE
Fixed doctype deprecated issue and loading script in foot file

### DIFF
--- a/app/views/includes/foot.jade
+++ b/app/views/includes/foot.jade
@@ -14,5 +14,5 @@ script(type='text/javascript', src='js/filters.js')
 script(type='text/javascript', src='js/services/global.js')
 
 script(type='text/javascript', src='js/controllers/index.js')
-script(type='text/javascript', src='js/controllers/header.js')	
+script(type='text/javascript', src='js/controllers/header.js')
 script(type='text/javascript', src='js/init.js')

--- a/app/views/layouts/default.jade
+++ b/app/views/layouts/default.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype
 html(lang='en', xmlns='http://www.w3.org/1999/xhtml', xmlns:fb='https://www.facebook.com/2008/fbml', itemscope='itemscope', itemtype='http://schema.org/Product')
   include ../includes/head
   body


### PR DESCRIPTION
Had a problem from cloning the repo and installing latest version of dependencies.
When running node server.js, it appeared to have some deprecated things.
And also the tab after the loading of header.js made an error so I correct it.
