### PR TITLE
Fixed minor formatting for jade

### DIFF
--- a/app/views/includes/foot.jade
+++ b/app/views/includes/foot.jade
@@ -14,5 +14,5 @@ script(type='text/javascript', src='js/filters.js')
 script(type='text/javascript', src='js/services/global.js')
 
 script(type='text/javascript', src='js/controllers/index.js')
-script(type='text/javascript', src='js/controllers/header.js')	
+script(type='text/javascript', src='js/controllers/header.js')
 script(type='text/javascript', src='js/init.js')

--- a/app/views/layouts/default.jade
+++ b/app/views/layouts/default.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html
 html(lang='en', xmlns='http://www.w3.org/1999/xhtml', xmlns:fb='https://www.facebook.com/2008/fbml', itemscope='itemscope', itemtype='http://schema.org/Product')
   include ../includes/head
   body


### PR DESCRIPTION
Hi, I made two changes to the file as I had these minor errors and it prevented me from loading the initial page.
1. In the default.jade file, the way to declare the file by "!!! 5" has been deprecated and so I replaced it with "doctype html".
2. In the foot.jade file, there was an extra space at the end of line 17 that was messing up the rendering because jade is sensitive to that kind of thing. So I deleted it.

It should make following the fantasyfootball tutorial easier.
